### PR TITLE
Adding new JDBC types. Notifying but not failing during model reading

### DIFF
--- a/src/main/java/org/apache/ddlutils/model/TypeMap.java
+++ b/src/main/java/org/apache/ddlutils/model/TypeMap.java
@@ -93,7 +93,20 @@ public abstract class TypeMap
     public static final String VARBINARY     = "VARBINARY";
     /** The string representation of the {@link java.sql.Types#VARCHAR} constant. */
     public static final String VARCHAR       = "VARCHAR";
-
+    /** The string representation of the {@link java.sql.Types#NVARCHAR} constant. */
+    public static final String NVARCHAR       = "NVARCHAR";
+    /** The string representation of the {@link java.sql.Types#NCHAR} constant. */
+    public static final String NCHAR          = "NCHAR";
+    /** The string representation of the {@link java.sql.Types#NVARCHAR} constant. */
+    public static final String LONGNVARCHAR       = "NVARCHAR";
+    /** The string representation of the {@link java.sql.Types#NCLOB} constant. */
+    public static final String NCLOB	      = "NCLOB";
+    /** The string representation of the {@link java.sql.Types#ROWID} constant. */
+    public static final String ROWID = "ROWID";
+    /** The string representation of the {@link java.sql.Types#SQLXML} constant. */
+    public static final String SQLXML = "SQLXML";
+    /** The string representation of the {@link java.sql.Types#SQLXML} constant. */
+    
     /** Maps type names to the corresponding {@link java.sql.Types} constants. */
     private static HashMap _typeNameToTypeCode = new HashMap();
     /** Maps {@link java.sql.Types} type code constants to the corresponding type names. */
@@ -110,6 +123,7 @@ public abstract class TypeMap
         registerJdbcType(Types.BLOB,          BLOB,          JdbcTypeCategoryEnum.BINARY);
         registerJdbcType(Types.BOOLEAN,       BOOLEAN,       JdbcTypeCategoryEnum.NUMERIC);
         registerJdbcType(Types.CHAR,          CHAR,          JdbcTypeCategoryEnum.TEXTUAL);
+        registerJdbcType(Types.NCHAR,      	  NCHAR,       	 JdbcTypeCategoryEnum.TEXTUAL);
         registerJdbcType(Types.CLOB,          CLOB,          JdbcTypeCategoryEnum.TEXTUAL);
         registerJdbcType(Types.DATALINK,      DATALINK,      JdbcTypeCategoryEnum.SPECIAL);
         registerJdbcType(Types.DATE,          DATE,          JdbcTypeCategoryEnum.DATETIME);
@@ -133,6 +147,13 @@ public abstract class TypeMap
         registerJdbcType(Types.TINYINT,       TINYINT,       JdbcTypeCategoryEnum.NUMERIC);
         registerJdbcType(Types.VARBINARY,     VARBINARY,     JdbcTypeCategoryEnum.BINARY);
         registerJdbcType(Types.VARCHAR,       VARCHAR,       JdbcTypeCategoryEnum.TEXTUAL);
+        registerJdbcType(Types.NVARCHAR,      NVARCHAR,      JdbcTypeCategoryEnum.TEXTUAL);
+        registerJdbcType(Types.NCHAR,      	  NCHAR,       	 JdbcTypeCategoryEnum.TEXTUAL);
+        registerJdbcType(Types.LONGNVARCHAR,  LONGNVARCHAR,  JdbcTypeCategoryEnum.TEXTUAL);
+        registerJdbcType(Types.NCLOB,      NCLOB,       JdbcTypeCategoryEnum.TEXTUAL);
+        registerJdbcType(Types.ROWID,      ROWID,       JdbcTypeCategoryEnum.TEXTUAL);
+        registerJdbcType(Types.SQLXML,     SQLXML,       JdbcTypeCategoryEnum.TEXTUAL);
+        
 
         // Torque/Turbine extensions which we only support when reading from an XML schema
         _typeNameToTypeCode.put("BOOLEANINT",  new Integer(Types.TINYINT));

--- a/src/main/java/org/apache/ddlutils/platform/JdbcModelReader.java
+++ b/src/main/java/org/apache/ddlutils/platform/JdbcModelReader.java
@@ -40,6 +40,7 @@ import org.apache.commons.collections.map.ListOrderedMap;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.ddlutils.DatabaseOperationException;
 import org.apache.ddlutils.Platform;
 import org.apache.ddlutils.PlatformInfo;
 import org.apache.ddlutils.model.CascadeActionEnum;
@@ -544,13 +545,21 @@ public class JdbcModelReader
 
             while (tableData.next())
             {
-                Map   values = readColumns(tableData, getColumnsForTable());
-                Table table  = readTable(metaData, values);
-
-                if (table != null)
-                {
-                    tables.add(table);
-                }
+            	try
+            	{
+	                Map   values = readColumns(tableData, getColumnsForTable());
+	                Table table  = readTable(metaData, values);
+	
+	                if (table != null)
+	                {
+	                    tables.add(table);
+	                }
+            	}
+            	catch(SQLException exception)
+            	{
+            		exception.printStackTrace();
+            		//continue
+            	}
             }
 
             final Collator collator = Collator.getInstance();


### PR DESCRIPTION
I've added some new JDBC types which are causing the new MS SQL server driver to fail while reading model. 

Plus I have added exception catching/printing stacktrace instead of failing. -- this part was useful in my case, i can remove this from PR if you think it is inappropriate handling.
